### PR TITLE
Actually ignore the jshint/htmlparser2 'retire' vulnerability

### DIFF
--- a/.retireignore
+++ b/.retireignore
@@ -1,1 +1,1 @@
-@jshint
+@htmlparser2

--- a/.retireignore
+++ b/.retireignore
@@ -1,1 +1,0 @@
-@htmlparser2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "index.js",
   "scripts": {
-    "test": "retire && jshint && tape test/*.js"
+    "test": "retire -p && jshint && tape test/*.js"
   },
   "devDependencies": {
     "jshint": "^2.5.10",


### PR DESCRIPTION
Ignore the vulnerable module htmlparser2, since retire doesn't intelligently ignore dependencies of ignored modules.

I stumbled on this project because I was also trying to .retireignore the htmlparser2 vulnerability in a jshint devDependency.  Might as well fix it here as well!

Ignoring `@jshint` previously worked because of a (bad) [bug](https://github.com/bekk/retire.js/commit/6a409d70c019cfc363036eb86cef8283f1adf2e6) in the retire 'ignore' logic which caused it to stop processing files for vulnerabilities once one on the ignore list was found.

Ideally, retire should support ignoring vulnerabilities in dependencies of ignored modules, but right now it doesn't.  There's [an open issue](https://github.com/bekk/retire.js/issues/67) relating to this, though there are certainly simpler solutions than the one proposed there.  Unfortunately, until this is fixed in the retire library the only thing to do is to globally ignore the htmlparser2 modules.

P.S. Hi @jfirebaugh!
