### PR TITLE
Add documentation-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ The following npm scripts are provided by package.json:
 
 * `npm run retire`: Check for vulnerable modules (run automatically as part of `npm test`)
 * `npm run lint`: Run linting (run automatically as part of `npm test`)
-* `run run docs`: Generate documentation from JSDoc comments. You should check in the resulting output, which is set up assuming you'll be publishing to GitHub pages.
+* `npm run docs-page`: Generate documentation from JSDoc comments. You should check in the resulting output, which is set up assuming you'll be publishing to GitHub pages.
+* `npm run docs-readme`: Generate documentation from JSDoc comments, and inject them into the README (this file), replacing the `## API` section.
 
 Feel free to adjust any of the defaults to taste after creating a new module.
+
+## API
+
+Document the module's API here

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "scripts": {
     "retire": "retire -p",
     "lint": "eslint *.js test",
-    "docs": "documentation --lint --github --format html --output .",
+    "docs-page": "documentation --lint --github --format html --output .",
+    "docs-readme": "documentation-readme -s API",
     "test": "npm run retire && npm run lint && tap --cov test/*.js"
   },
   "devDependencies": {
     "documentation": "^2.1.0-alpha2",
+    "documentation-readme": "^2.0.0",
     "eslint": "^1.6.0",
     "eslint-config-mourner": "^1.0.1",
     "retire": "*",


### PR DESCRIPTION
This is a nice starter repo, which I'm forking for my own use -- thanks!

Since most of the js modules I make are small enough that their API can fit comfortably in the README, so `documentation-readme` is a better fit... just figured I'd PR this back to you in case you want it.
